### PR TITLE
DPI-2835: Package flipExampleData in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipExampleData";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = "Example data used for testing flip projects.";
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    stringi
+ ];
+
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipExampleData in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR